### PR TITLE
Add HTML validation workflow

### DIFF
--- a/.github/workflows/test-html.yml
+++ b/.github/workflows/test-html.yml
@@ -1,0 +1,22 @@
+name: Test HTML
+on:
+  pull_request:
+  push:
+    branches: [main]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Generate index.html
+        uses: docker://pandoc/core:3.1.1.0
+        with:
+          args: >-
+            --standalone --template=template.html --output=index.html README.md
+      - name: Validate title tag
+        run: |
+          count=$(grep -o '<title>' index.html | wc -l)
+          if [ "$count" -ne 1 ]; then
+            echo "Expected exactly one <title> tag, found $count"
+            exit 1
+          fi


### PR DESCRIPTION
## Summary
- validate generated index.html from README using pandoc
- fail workflow if more than one `<title>` tag is found

## Testing
- `pre-commit run --files .github/workflows/test-html.yml`

------
https://chatgpt.com/codex/tasks/task_e_68400fa751e0832aa80818df17e00214